### PR TITLE
Ignore package.el's insistance on initializing in init.el

### DIFF
--- a/configuration.org
+++ b/configuration.org
@@ -6,6 +6,12 @@ started with Org mode" [[https://www.youtube.com/watch?v%3DSzA2YODtgK4][talk]].
 
 * Package management
 
+** Prevent package manager from polluting the init.el
+
+#+BEGIN_SRC emacs-lisp
+  (setq package--init-file-ensured t)
+#+END_SRC
+
 ** Use the built-in (Emacs 24+) package manager
 
 Look for packages in the GNU Emacs package repository as well as a few community repositories


### PR DESCRIPTION
Summary
----------

The package system is configured in configuration.org then
initialized. Package.el seems to, for no good reason, insist that it
is initialized in the init.el, before the package system is properly
configured. This change tricks package.el into thinking that it has
already mucked with the init.el so it leaves it alone on startup. This
allows the configuration.org to properly configure and initialize the
package system.